### PR TITLE
Expected handling of double quoted quotes - RFC 4180

### DIFF
--- a/src/classes/RT_CSVReader.cls
+++ b/src/classes/RT_CSVReader.cls
@@ -90,7 +90,7 @@ public class RT_CSVReader implements Iterable<List<String>>, Iterator<List<Strin
 				
 				//Does it contain double quoted quotes? I.e. Escaped double quotes
                 		Integer doubleQuotedQuotesIndex = currentValue.indexOf(DOUBLE_QUOTE);
-                		if(doubleQuotedQuotesIndex > 0) {
+                		if(doubleQuotedQuotesIndex >= 0) {
                     			// Replace double quoted quotes with double quotes.
                     			currentValue = currentValue.replace(DOUBLE_QUOTE, QUOTE);
                 		}

--- a/src/classes/RT_CSVReader.cls
+++ b/src/classes/RT_CSVReader.cls
@@ -86,7 +86,16 @@ public class RT_CSVReader implements Iterable<List<String>>, Iterator<List<Strin
 			}
 			else if (currentValue.endsWith(QUOTE)) {
 				Integer lastIndex = currentValue.length() - 1;
-				tmpValues.add(currentValue.substring(1, lastIndex));
+				currentValue = currentValue.substring(1, lastIndex);
+				
+				//Does it contain double quoted quotes? I.e. Escaped double quotes
+                		Integer doubleQuotedQuotesIndex = currentValue.indexOf(DOUBLE_QUOTE);
+                		if(doubleQuotedQuotesIndex > 0) {
+                    			// Replace double quoted quotes with double quotes.
+                    			currentValue = currentValue.replace(DOUBLE_QUOTE, QUOTE);
+                		}
+				
+				tmpValues.add(currentValue);
 				if (foundAt == nlAt) {
 					break;
 				}

--- a/src/classes/RT_CSVReaderTest.cls
+++ b/src/classes/RT_CSVReaderTest.cls
@@ -3,7 +3,7 @@
 	@isTest static void testCSVReader1() {
 		String csvString = 'fieldName1,fieldName2,fieldName3,fieldName4\r\n' +
 		                   '"valu,e a1","value\nb1",value c1,\n' +
-		                   'value a2,"value\"b2","valu""e c2",\r\n' +
+		                   'value a2,"value""b2","valu""e c2",\r\n' +
 		                   ',value\"b3,value\'c3,\'value d3\'\n' +
 		                   '"value,a4","",,\'value d4\'';
 		                   
@@ -16,7 +16,7 @@
 		
 		System.assertEquals('value a2', data[2][0]);
 		System.assertEquals('value"b2', data[2][1]);
-		System.assertEquals('valu""e c2', data[2][2]);
+		System.assertEquals('valu"e c2', data[2][2], 'Expected handling of double quoted quotes');
 		System.assertEquals('', data[2][3]);
 		
 		System.assertEquals('', data[3][0]);


### PR DESCRIPTION
From the summary of RFC 4180 in Wikipedia (I know, quote actual sources, but this isn't a college project):

 > If double-quotes are used to enclose fields, then a double-quote must be represented by two double-quote characters.

This is to address Issue #1 